### PR TITLE
[DEX] Make basecoin flexible to a max

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -1962,7 +1962,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "# Cell 38a\n",
@@ -1975,7 +1977,7 @@
     "    .nid(NID)\\\n",
     "    .nonce(100)\\\n",
     "    .method(\"add\")\\\n",
-    "    .params({'_baseToken': contracts['bal']['SCORE'], '_quoteToken': contracts['icd']['SCORE'], '_baseValue': 100 * ICX, '_quoteValue': 30990197728645406}) \\\n",
+    "    .params({'_baseToken': contracts['bal']['SCORE'], '_quoteToken': contracts['icd']['SCORE'], '_maxBaseValue': 100 * ICX, '_quoteValue': 30990197728645406}) \\\n",
     "    .build()\n",
     "signed_transaction = SignedTransaction(transaction, wallet)\n",
     "tx_hash = icon_service.send_transaction(signed_transaction)\n",
@@ -1996,6 +1998,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Cell 40\n",
+    "\n",
+    "call = CallBuilder().from_(wallet.get_address())\\\n",
+    "                    .to(contracts['dex']['SCORE'])\\\n",
+    "                    .method('getPrice')\\\n",
+    "                    .params({'_pid': 2}) \\\n",
+    "                    .build()\n",
+    "result = icon_service.call(call)\n",
+    "p2_price = int(result, 0)\n",
+    "print(p2_price)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Cell 38b\n",
     "\n",
     "transaction = CallTransactionBuilder()\\\n",
@@ -2006,7 +2026,7 @@
     "    .nid(NID)\\\n",
     "    .nonce(100)\\\n",
     "    .method(\"add\")\\\n",
-    "    .params({'_baseToken': contracts['sicx']['SCORE'], '_quoteToken': contracts['icd']['SCORE'], '_baseValue': 1 * ICX, '_quoteValue': 1 * ICX}) \\\n",
+    "    .params({'_baseToken': contracts['sicx']['SCORE'], '_quoteToken': contracts['icd']['SCORE'], '_maxBaseValue': 1 * ICX , '_quoteValue': 1 * ICX}) \\\n",
     "    .build()\n",
     "signed_transaction = SignedTransaction(transaction, wallet)\n",
     "tx_hash = icon_service.send_transaction(signed_transaction)\n",
@@ -2062,11 +2082,11 @@
     "\n",
     "call = CallBuilder().from_(wallet.get_address())\\\n",
     "                    .to(contracts['dex']['SCORE'])\\\n",
-    "                    .method('getInversePrice')\\\n",
+    "                    .method('getPrice')\\\n",
     "                    .params({'_pid': 2}) \\\n",
     "                    .build()\n",
     "result = icon_service.call(call)\n",
-    "int(result, 0) / 10**10"
+    "int(result, 0)"
    ]
   },
   {
@@ -2083,7 +2103,7 @@
     "                    .params({'_pid': 2, '_token': contracts['icd']['SCORE']}) \\\n",
     "                    .build()\n",
     "result = icon_service.call(call)\n",
-    "int(result, 0) / 10**18"
+    "int(result, 0)"
    ]
   },
   {


### PR DESCRIPTION
Before, the pool expected an exact amount to be supplied. This was difficult, as the user
had to supply amounts in the exact proportion to the pool. Now, the pool will use an exact
amount of quote coin, and up to the needed amount of basecoin to fit the pool requirement.

For example, a pool might have a 2 - 1 ratio of basecoin to quote coin. A use supplying 1 ICD could send
2, or 2 + some small buffer of basecoin and a proportional amount to the quotecoin would be supplied.
Unused basecoin is left on deposit.