### PR TITLE
[DEX] Fix combined withdraw on easy remove (#85)

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1261,12 +1261,14 @@ class DEX(IconScoreBase):
         self.Remove(_pid, self.msg.sender, _value)
         self.TransferSingle(self.msg.sender, self.msg.sender, Address.from_string(
             ZERO_SCORE_ADDRESS), _pid, _value)
-        if not _withdraw:
-            self._deposit[token1][self.msg.sender] += token1_amount
-            self._deposit[token2][self.msg.sender] += token2_amount
-        else:
+
+        self._deposit[token1][self.msg.sender] += token1_amount
+        self._deposit[token2][self.msg.sender] += token2_amount
+
+        if _withdraw:
             self.withdraw(token1, token1_amount)
             self.withdraw(token2, token2_amount)
+
         self._update_account_snapshot(self.msg.sender, _pid)
         self._update_total_supply_snapshot(_pid)
 


### PR DESCRIPTION
Before, the balance check was improperly doubled (so you had to have enough on deposit
AND in the contract when doing the easy remove. The easy remove method creates 2 txns
which send the assets directly to the user's wallet, instead of leaving them in
the DEX to switch to another pool.

Fixes #85 