### PR TITLE
Do not rely on implicit float significant digits display

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -416,7 +416,7 @@ class DEX(IconScoreBase):
         self._quote_coins.add(_address)
     
     @external(readonly=True)
-    def isQuoteCoinAllowed(self, _address: Address) -> None:
+    def isQuoteCoinAllowed(self, _address: Address) -> bool:
         """
         :param _address: address of to check as allowable quote
         """

--- a/core_contracts/loans/loans/loans.py
+++ b/core_contracts/loans/loans/loans.py
@@ -600,7 +600,7 @@ class Loans(IconScoreBase):
         if repaid != 0:
             self._assets[symbol].burn(repaid)
         self.LoanRepaid(_from, symbol, repaid,
-            f'Loan of {repaid / EXA} {symbol} repaid to Balanced.')
+            f'Loan of {repaid} {symbol} repaid to Balanced.')
         self.check_dead_markets()
         pos.update_standing()
 
@@ -657,7 +657,7 @@ class Loans(IconScoreBase):
         self._send_token(symbol, self._dividends.get(), fee, "Redemption fee.")
         self.check_dead_markets()
         self.AssetRedeemed(_from, symbol, _value,
-            f'{_value / EXA} {symbol} redeemed on Balanced at price {price / EXA} ICX/{symbol}.')
+            f'{_value} {symbol} redeemed on Balanced at price {price} ICX/{symbol}.')
 
     def bd_redeem(self, _from: Address,
                         _asset: Asset,
@@ -748,7 +748,7 @@ class Loans(IconScoreBase):
         # Originate loan
         pos[_asset] += _amount + fee
         self.OriginateLoan(_from, _asset, _amount,
-            f'Loan of {_amount / EXA} {_asset} from Balanced.')
+            f'Loan of {_amount} {_asset} from Balanced.')
         self._assets[_asset].mint(_from, _amount)
 
         # Pay fee

--- a/core_contracts/staking/staking.py
+++ b/core_contracts/staking/staking.py
@@ -511,7 +511,7 @@ class Staking(IconScoreBase):
                                               dict_prep_delegation[1], prep_delegations)
         self._stake_and_delegate(self._check_for_week())
         self._sICX_supply.set(self._sICX_supply.get() + amount)
-        self.TokenTransfer(_to, amount, f'{amount / DENOMINATOR} sICX minted to {_to}')
+        self.TokenTransfer(_to, amount, f'{amount // DENOMINATOR} sICX minted to {_to}')
         return amount
 
     def _claim_iscore(self) -> None:


### PR DESCRIPTION
- Eventlog emissions should be deterministic, thus do not rely on implicit float significant digits display which could be different between Python versions