### PR TITLE
[DEX] No add/remove/swap without _dex_on (#57)

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -446,6 +446,7 @@ class DEX(IconScoreBase):
         return self._time_offset.get()
 
     @payable
+    @dex_on
     def fallback(self):
         """
         Payable method called by sending ICX directly into the SCORE.
@@ -490,6 +491,7 @@ class DEX(IconScoreBase):
         self._update_total_supply_snapshot(self._SICXICX_POOL_ID)
 
     @external
+    @dex_on
     def cancelSicxicxOrder(self):
         """
         Cancels user's order in the SICXICX queue.
@@ -881,6 +883,7 @@ class DEX(IconScoreBase):
     ####################################
     # Internal exchange function
 
+    @dex_on
     def exchange(self, _fromToken: Address, _toToken: Address, _sender: Address, _receiver: Address, _value: int, _max_slippage: int = 250):
         lp_fees = (_value * self._pool_lp_fee.get()) // FEE_SCALE
         baln_fees = (_value * self._pool_baln_fee.get()) // FEE_SCALE
@@ -1258,6 +1261,7 @@ class DEX(IconScoreBase):
         self.Withdraw(_token, self.msg.sender, _value)
 
     @external
+    @dex_on
     def remove(self, _pid: int, _value: int, _withdraw: bool = False):
         """
         :param _pid: The pool ID the user wishes to stop contributing to
@@ -1310,6 +1314,7 @@ class DEX(IconScoreBase):
         self._update_total_supply_snapshot(_pid)
 
     @external
+    @dex_on
     def add(self, _baseToken: Address, _quoteToken: Address, _maxBaseValue: int, _quoteValue: int):
         """
         Adds liquidity to a pool for trading, or creates a new pool. Rules:

--- a/core_contracts/dex/utils/checks.py
+++ b/core_contracts/dex/utils/checks.py
@@ -38,3 +38,17 @@ def only_owner(func):
 
 		return func(self, *args, **kwargs)
 	return __wrapper
+
+
+def dex_on(func):
+	if not isfunction(func):
+		revert(f"NotAFunctionError")
+
+	@wraps(func)
+	def __wrapper(self: object, *args, **kwargs):
+		if not self._dex_on.get():
+			revert("NotLaunched: Function cannot be called before the DEX is turned on")
+
+		return func(self, *args, **kwargs)
+	return __wrapper
+


### PR DESCRIPTION
Fixes #57

Introduces a decorator `@dex_on`. This prevents users from creating pool,
swapping or withdrawing LP tokens while the param `_dex_on` hasn't been set by governance.
This mirrors the behavior on other contracts that also prevent this behavior.