### PR TITLE
Pool Optimization (#110)

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# Cell 0\n",
     "\n",
-    "network = \"testnet\"  # set this to one of mainnet, yeouido, euljiro, pagoda, or custom\n",
+    "network = \"custom\"  # set this to one of mainnet, yeouido, euljiro, pagoda, or custom\n",
     "\n",
     "connections = {\n",
     "\"mainnet\": {\"iconservice\": \"https://ctz.solidwallet.io\",       \"nid\": 1},\n",
@@ -509,7 +509,7 @@
     "\n",
     "results1 = {}\n",
     "for tx in txns:\n",
-    "    res = send_tx(tx[\"contract\"], tx[\"value\"], tx[\"method\"], tx[\"params\"], wallet)\n",
+    "    res = send_tx(tx[\"contract\"], tx[\"value\"], tx[\"method\"], tx[\"params\"], btest_wallet)\n",
     "    results1[f'{tx[\"contract\"]}|{tx[\"method\"]}|{tx[\"params\"]}'] = res"
    ]
   },
@@ -1955,7 +1955,7 @@
     "# Cell 45\n",
     "\n",
     "to_token = contracts['sicx']['SCORE']\n",
-    "params_data = \"{\\\"method\\\": \\\"_swap\\\", \\\"params\\\": {\\\"toToken\\\":\\\"\" + str(to_token) + \"\\\", \\\"maxSlippage\\\":10}}\"\n",
+    "params_data = \"{\\\"method\\\": \\\"_swap\\\", \\\"params\\\": {\\\"toToken\\\":\\\"\" + str(to_token) + \"\\\", \\\"maxSlippage\\\":190}}\"\n",
     "data = params_data.encode(\"utf-8\")\n",
     "params = {'_to': contracts['dex']['SCORE'], '_value': ICX // 100, '_data': data}\n",
     "transaction = CallTransactionBuilder()\\\n",

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -973,8 +973,8 @@ class DEX(IconScoreBase):
         self._pool_total[_pid][_fromToken] = new_token1
         self._pool_total[_pid][_toToken] = new_token2
 
-        total_base = new_token2 if is_sell else new_token1
-        total_quote = new_token1 if is_sell else new_token1
+        total_base = new_token1 if is_sell else new_token2
+        total_quote = new_token2 if is_sell else new_token1
 
         send_price = (EXA * _value) // send_amt
 
@@ -1469,11 +1469,8 @@ class DEX(IconScoreBase):
             if quote_from_base <= _quoteValue:
                 quote_to_commit = quote_from_base
 
-            elif base_from_quote <= _baseValue:
-                base_to_commit = base_from_quote
-
             else:
-                revert("AddLiquidityError: Unable to add to pool in supplied ratio")
+                base_to_commit = base_from_quote
 
             liquidity_from_base = (self._total[_pid] * base_to_commit) // self._pool_total[_pid][_baseToken]
             liquidity_from_quote = (self._total[_pid] * quote_to_commit) // self._pool_total[_pid][_quoteToken]


### PR DESCRIPTION
Fixes #110
Fixes #129

This changes the `add` method to maximize the liquidity based on the supplied parameters.
Adds eventlogs used in both `add` and `swap` events.
Adds a `getPoolStats()` endpoints that gives an aggregated view of tracked quantities, so
the geometry labs backend can track it.

Now, when calling `add`, any extra tokens are automatically removed back to the user's address
if they set a `withdraw` param to true.

Adds extra validation to the withdraw method, to avoid sending a negative number and diluting other
LPs (critical bugfix).

Creates combined methods to take out loans, stake ICX and create a pool in the jupyter notebook.
These can help speed testing of the sICX/bnUSD pool, and can serve as the guideline for unit tests.