### PR TITLE
Normalize added LP tokens (#104)

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -10,6 +10,7 @@ from .scorelib.utils import *
 from .utils.checks import *
 from .utils.consts import *
 from .lp_metadata import *
+from .utils.scoremath import *
 
 
 # An interface to the Rewards SCORE
@@ -1494,7 +1495,12 @@ class DEX(IconScoreBase):
             self._pool_base[_pid] = _baseToken
             self._pool_quote[_pid] = _quoteToken
 
-            liquidity = DEFAULT_INITAL_LP
+            liquidity = sqrt(_baseValue * _quoteValue)
+
+            if liquidity < MIN_LIQUIDITY:
+                revert(f"InsufficientInitialLiquidity: Initial LP tokens must exceed {MIN_LIQUIDITY}")
+
+
             self.MarketAdded(_pid, _baseToken, _quoteToken,
                              _baseValue, _quoteValue)
 

--- a/core_contracts/dex/utils/scoremath.py
+++ b/core_contracts/dex/utils/scoremath.py
@@ -1,0 +1,14 @@
+from iconservice import *
+
+def sqrt(x: int) -> int:
+    """
+    Babylonian Square root implementation
+    """
+    z = (x + 1) // 2
+    y = x
+    
+    while z < y:
+        y = z
+        z = ( (x // z) + z) // 2
+    
+    return y


### PR DESCRIPTION
This adds a babylonian sqrt implementation used to calculate normalized LP tokens.

Instead of assigning LPs a fixed amount of tokens as before this approach does:

```
sqrt(token_a_amount * token_b_amount)
```

It additionally requires that the amount of LP tokens is greater than the minimum
liquidity. These amounts are based on the smallest unit of tokens, not scaled up
by their precision (1000 loop, not 1000 icx is the requirement, for example).

Fixes #104