### PR TITLE
fix getEmission method.

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -448,6 +448,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "send_tx('governance', 0, 'balanceToggleStakingEnabled', {}, btest_wallet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# # Set delegations for the Loans SCORE\n",
     "\n",
     "# preps = {\"hx23823847f593ecb65c9e1ea81a789b02766280e8\",\n",
@@ -505,7 +514,7 @@
     "\n",
     "compress()\n",
     "update = 1\n",
-    "contract = contracts['loans']\n",
+    "contract = contracts['rewards']\n",
     "params = {}\n",
     "# params = {'_governance': contracts['governance']['SCORE']}\n",
     "deploy_SCORE(contract, params, btest_wallet, update)\n"

--- a/core_contracts/rewards/rewards.py
+++ b/core_contracts/rewards/rewards.py
@@ -63,6 +63,8 @@ class Rewards(IconScoreBase):
     @external(readonly=True)
     def getEmission(self, _day: int = -1) -> int:
         if _day < 1:
+            _day += self._get_day() + 1
+        if _day < 1:
             revert(f'{TAG}: Invalid day.')
         return self._daily_dist(_day)
 


### PR DESCRIPTION
Add toggleStakingEnabled cell in clean install flow. Not sure how this appears to still not be merged. I thought I just did this.