### PR TITLE
[audit] Remove duplicate pool total (#169)

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -215,9 +215,6 @@ class DEX(IconScoreBase):
         # active[pool] = bool
         self.active = DictDB('activePool', db, value_type=bool)
 
-        # poolTotal[nonce][tokenAddress] = intAmount
-        self._pool_total = DictDB('poolTotal', db, value_type=int, depth=2)
-
         # Swap queue for sicxicx
         self._icx_queue = LinkedListDB(
             'icxQueue', db, value1_type=int, value2_type=Address)


### PR DESCRIPTION
Removes declaration of `_pool_total` as per audit feedback.

Fixes #169