### PR TITLE
Add APY API to rewards for Loans and DEX pools

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -448,6 +448,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "send_tx('governance', 0, 'balanceToggleStakingEnabled', {}, btest_wallet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# # Set delegations for the Loans SCORE\n",
     "\n",
     "# preps = {\"hx23823847f593ecb65c9e1ea81a789b02766280e8\",\n",
@@ -505,7 +514,7 @@
     "\n",
     "compress()\n",
     "update = 1\n",
-    "contract = contracts['loans']\n",
+    "contract = contracts['rewards']\n",
     "params = {}\n",
     "# params = {'_governance': contracts['governance']['SCORE']}\n",
     "deploy_SCORE(contract, params, btest_wallet, update)\n"

--- a/core_contracts/loans/loans/loans.py
+++ b/core_contracts/loans/loans/loans.py
@@ -473,6 +473,16 @@ class Loans(IconScoreBase):
         return self._positions._snapshot_db[_snapshot_id].total_mining_debt.get()
 
     @external(readonly=True)
+    def getBnusdValue(self, _name: str) -> int:
+        """
+        Returns the total bnUSD value of loans mining BALN for APY calculation.
+        """
+        bnUSD_price = self._assets['bnUSD'].lastPriceInLoop()
+        loop_value = self._positions._snapshot_db[-1].total_mining_debt.get()
+        return EXA * loop_value // bnUSD_price
+
+
+    @external(readonly=True)
     def getDataCount(self, _snapshot_id: int) -> int:
         """
         Returns the number of records in the snapshot.

--- a/core_contracts/rewards/RewardData.py
+++ b/core_contracts/rewards/RewardData.py
@@ -13,7 +13,15 @@ class DataSourceInterface(InterfaceScore):
         pass
 
     @interface
+    def getBnusdValue(self, _name: str) -> int:
+        pass
+
+    @interface
     def getDataBatch(self, _name: str, _snapshot_id: int, _limit: int, _offset: int = 0) -> dict:
+        pass
+
+    @interface
+    def getBalnPrice(self) -> int:
         pass
 
 
@@ -73,6 +81,10 @@ class DataSource(object):
 
     def set_dist_percent(self, _dist_percent: int) -> None:
         self.dist_percent.set(_dist_percent)
+
+    def get_value(self) -> int:
+        data_source = self._rewards.create_interface_score(self.contract_address.get(), DataSourceInterface)
+        return data_source.getBnusdValue(self.name.get())
 
     def get_data(self) -> dict:
         return {

--- a/core_contracts/rewards/rewards.py
+++ b/core_contracts/rewards/rewards.py
@@ -234,6 +234,26 @@ class Rewards(IconScoreBase):
             index = _day - 60
             return max(((995 ** index) * 10 ** 23) // (1000 ** index), 1250 * 10 ** 18)
 
+    @external(readonly=True)
+    def getAPY(self, _name: str) -> int:
+        """
+        Returns an approximate APY for miners.
+
+        :param _name: Data source name.
+        :type _name: str
+
+        :return: APY * 10**18
+        :rtype int
+        """
+        dex = self._data_source_db['sICX/ICX']
+        dex_score = self.create_interface_score(dex._contract_address.get(), DataSourceInterface)
+        source = self._data_source_db[_name]
+        score = self.create_interface_score(source._contract_address.get(), DataSourceInterface)
+        emission = self.getEmission(-1)
+        baln_price = dex_score.getBalnPrice()
+        percent = source.dist_percent.get()
+        return 365 * emission * percent * baln_price / (EXA * source.get_value())
+
     @external
     def tokenFallback(self, _from: Address, _value: int, _data: bytes) -> None:
         """

--- a/core_contracts/rewards/rewards.py
+++ b/core_contracts/rewards/rewards.py
@@ -63,6 +63,8 @@ class Rewards(IconScoreBase):
     @external(readonly=True)
     def getEmission(self, _day: int = -1) -> int:
         if _day < 1:
+            _day += self._get_day() + 1
+        if _day < 1:
             revert(f'{TAG}: Invalid day.')
         return self._daily_dist(_day)
 


### PR DESCRIPTION
A method to get the APY is now available on the rewards SCORE:
rewards.getAPY(_name: str) -> int

Returns an integer APY * 10**18
