### PR TITLE
Switch to linked list for nonzero deltas.

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -514,7 +514,7 @@
     "\n",
     "compress()\n",
     "update = 1\n",
-    "contract = contracts['dex']\n",
+    "contract = contracts['loans']\n",
     "params = {}\n",
     "# params = {'_governance': contracts['governance']['SCORE']}\n",
     "deploy_SCORE(contract, params, btest_wallet, update)\n"
@@ -728,7 +728,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range(100):\n",
+    "for i in range(120, 200):\n",
     "    send_icx(wallets[i].get_address(), 2000 * ICX, btest_wallet)"
    ]
   },
@@ -738,7 +738,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range(100):\n",
+    "for i in range(200):\n",
     "    print(f'{i:3d}: {wallets[i].get_address()}: {icon_service.get_balance(wallets[i].get_address()) / 10**18: 9.3f}')"
    ]
   },
@@ -783,7 +783,7 @@
    "source": [
     "# Mint some bnUSD to first 70 wallets.\n",
     "\n",
-    "for i in range(70):\n",
+    "for i in range(150):\n",
     "    res = send_tx('loans', 500 * ICX, 'depositAndBorrow', {'_asset': 'bnUSD', '_amount': 100 * ICX}, wallets[i])\n"
    ]
   },
@@ -830,7 +830,7 @@
     "# redeem 10 bnUSD from each of 20 wallets that do not have positions on Balanced. This will use up all\n",
     "# of the liquidation pool and require some replay events to be recorded.\n",
     "\n",
-    "for i in range(10):\n",
+    "for i in range(60, 80):\n",
     "    params = {'_to': wallets[i+100].get_address(), '_value': 20 * ICX}\n",
     "    res = send_tx('bnUSD', 0, 'transfer', params, wallets[i])\n",
     "    sleep(2)\n",

--- a/core_contracts/loans/loans/loans.py
+++ b/core_contracts/loans/loans/loans.py
@@ -317,10 +317,10 @@ class Loans(IconScoreBase):
         """
         pos = self._positions
         snap = pos._snapshot_db[-1]
-        nonzero = len(pos.get_nonzero()) + len(snap.add_to_nonzero) - len(snap.remove_from_nonzero)
+        nonzero = len(pos.get_nonzero()) + len(snap.get_add_nonzero()) - len(snap.get_remove_nonzero())
         if snap.snap_day.get() > 1:
             last_snap = pos._snapshot_db[-2]
-            nonzero += len(last_snap.add_to_nonzero) - len(last_snap.remove_from_nonzero)
+            nonzero += len(last_snap.get_add_nonzero()) - len(last_snap.get_remove_nonzero())
         return nonzero
 
     @external(readonly=True)

--- a/core_contracts/loans/loans/snapshots.py
+++ b/core_contracts/loans/loans/snapshots.py
@@ -1,4 +1,5 @@
 from iconservice import *
+from ..scorelib.linked_list import *
 
 TAG = 'BalancedLoansSnapshots'
 SNAP_DB_PREFIX = b'snaps'
@@ -7,6 +8,7 @@ SNAP_DB_PREFIX = b'snaps'
 class Snapshot(object):
 
     def __init__(self, db: IconScoreDatabase, loans: IconScoreBase) -> None:
+        self._db = db
         self._loans = loans
         self.snap_day = VarDB('snap_day', db, int)
         # Time of snapshot
@@ -26,12 +28,12 @@ class Snapshot(object):
         # will be compiled in the precompute method as each position in the
         # nonzero ArrayDB is brought up to date.
         self.mining = ArrayDB('mining', db, int)
-        # List of position ids that changed to non-zero collateral status since the last snap.
-        # used to update the nonzero ArrayDB during calls to the precompute method.
-        self.add_to_nonzero = ArrayDB('add_to_nonzero', db, int)
-        # List of position ids that changed to a zero collateral status since the last snap.
-        # used to update the nonzero ArrayDB during calls to the precompute method.
-        self.remove_from_nonzero = ArrayDB('remove_from_nonzero', db, int)
+
+    def get_add_nonzero(self) -> LinkedListDB:
+        return LinkedListDB('add_to_nonzero', self._db, value_type=int)
+
+    def get_remove_nonzero(self) -> LinkedListDB:
+        return LinkedListDB('remove_from_nonzero', self._db, value_type=int)
 
     def to_dict(self) -> dict:
         """
@@ -52,8 +54,8 @@ class Snapshot(object):
             'prices': prices,
             'mining_count': len(self.mining),
             'precompute_index': self.precompute_index.get(),
-            'add_to_nonzero_count': len(self.add_to_nonzero),
-            'remove_from_nonzero_count': len(self.remove_from_nonzero)
+            'add_to_nonzero_count': len(self.get_add_nonzero()),
+            'remove_from_nonzero_count': len(self.get_remove_nonzero())
         }
         return snap
 

--- a/core_contracts/loans/scorelib/linked_list.py
+++ b/core_contracts/loans/scorelib/linked_list.py
@@ -213,6 +213,10 @@ class LinkedListDB:
         node.set_value(value)
         node.repack()
 
+    def __contains__(self, node_id: int) -> bool:
+        node = self._node(node_id)
+        return node.exists()
+
     def _node(self, node_id) -> _Node:
         return _Node(str(node_id) + self._name, self._db, self._value_type)
 
@@ -224,6 +228,7 @@ class LinkedListDB:
             raise LinkedNodeAlreadyExists(self._name, node_id)
 
         node.set_value(value)
+        node.repack()
         return node_id, node
 
     def set_node_value(self, value, node_id: int) -> None:


### PR DESCRIPTION
There was a concern that the number of nonzero deltas could be very large if we have a day with high numbers of people joining or cashing out. Since these were stored in an ArrayDB it could have led to failures if they got too large. This PR changes them to LinkedLists.
Fixes #177 
