### PR TITLE
Hotfix/rewards lock

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1495,7 +1495,7 @@ class DEX(IconScoreBase):
         if _offset < 0:
             revert(f"{TAG}: Offset must be equal to or greater than Zero.")
         rv = {}
-        for addr in self._active_addresses[_id].range(_offset, _offset + MAX_ITERATION_LOOP):
+        for addr in self._active_addresses[_id].range(_offset, _offset + _limit):
             snapshot_balance = self.balanceOfAt(addr, _id, _snapshot_id)
             if snapshot_balance:
                 rv[str(addr)] = snapshot_balance

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -498,6 +498,8 @@ class DEX(IconScoreBase):
         self._take_new_day_snapshot()
         self._check_distributions()
 
+        self._revert_on_incomplete_rewards()
+
         if self.msg.value < 10 * EXA:
             revert(f"{TAG}: Minimum pool contribution is 10 ICX.")
 
@@ -533,6 +535,8 @@ class DEX(IconScoreBase):
         """
         self._take_new_day_snapshot()
         self._check_distributions()
+
+        self._revert_on_incomplete_rewards()
 
         if not self._icx_queue_order_id[self.msg.sender]:
             revert(f"{TAG}: No open order in sICX/ICX queue.")
@@ -1013,6 +1017,14 @@ class DEX(IconScoreBase):
             self._staking.get(), stakingInterface)
         return staking_score.getTodayRate()
 
+    def _revert_on_incomplete_rewards(self):
+        """
+        Until the cursor release of Balanced is complete, this is a stop-gap
+        function that prevents contract lockup.
+        """
+        if not self._rewards_done.get():
+            revert(f"{TAG} Rewards distribution in progress, please try again shortly")
+
     ####################################
     # Internal exchange function
 
@@ -1115,6 +1127,8 @@ class DEX(IconScoreBase):
         Perform an instant conversion from SICX to ICX.
         Gets orders from SICXICX queue by price time precedence.
         """
+        self._revert_on_incomplete_rewards()
+
         # Amount of ICX in one unit sICX
         sicx_icx_price = self._get_sicx_rate()
 
@@ -1551,6 +1565,8 @@ class DEX(IconScoreBase):
         self._take_new_day_snapshot()
         self._check_distributions()
 
+        self._revert_on_incomplete_rewards()
+
         balance = self._balance[_id][self.msg.sender]
 
         if not self.active[_id]:
@@ -1618,6 +1634,8 @@ class DEX(IconScoreBase):
 
         self._take_new_day_snapshot()
         self._check_distributions()
+
+        self._revert_on_incomplete_rewards()
 
         _owner = self.msg.sender
         _id = self._pool_id[_baseToken][_quoteToken]


### PR DESCRIPTION
There were a couple issues with rewards. Previously, 100 iterations were tested in most configs, and we missed that it didn't honor the `limit` param supplied with the request.

Additionally, users could be missed or incorrectly issued rewards while the dataset could move around. An effective longer-term solution for this would be preparing a list of state mutations `active_addresses` (improving from a previously discussed fix) and applying them in a `precompute` method, turning it into a cursor.

This takes a bit longer to get correct. For now, a stop-gap solution is to put a write lock on quantities tracked by rewards, while rewards are issued. The following methods should be blocked while rewards are mid-compute:

- `swap_icx_` - sicx swaps against the queue)
- `fallaback` (the default payable - ICX deposits into the queue)
- `add` - provides liquidity
- `remove` - removes liquidity
- `cancelSicxicxOrder` - removes icx queue liquidity

This method doesn't impact any quantity relevant to rewards, and stays functional:
- `exchange` - swaps in a pool (not icx queue)

The exchange method can help drive compute on the rewards score while the other dex write lock is in place. Other sources of replaying transactions will come from the loans score, and manual calls of the distribute method. The write lock method should be removed in the future once good cursor behavior is added in.

Here's some functions that can be used to test/verify in jupyter:

**Trigger rewards distribution**
```
transaction = CallTransactionBuilder()\
    .from_(wallet.get_address())\
    .to(contracts['rewards']['SCORE'])\
    .value(0)\
    .step_limit(30000000)\
    .nid(NID)\
    .nonce(100)\
    .method("distribute")\
    .build()
signed_transaction = SignedTransaction(transaction, wallet)
tx_hash = icon_service.send_transaction(signed_transaction)
tx_hash
res = get_tx_result(tx_hash)
print(f'Status: {res["status"]}')
if len(res["eventLogs"]) > 0:
    for item in res["eventLogs"]:
        print(f'{item} \n')
if res['status'] == 0:
    print(f'Failure: {res["failure"]}')
```

**Check distribution status**
```
call = CallBuilder().from_(wallet.get_address())\
                    .to(contracts['rewards']['SCORE'])\
                    .method('distStatus')\
                    .build()
result = icon_service.call(call)
print(result)
```

A local test was done with:
- 250 addresses providing liquidity to the icx queue
- 30 addresses in the sicx/bnusd pool
- 30 addresses borrowing bnUSD
