### PR TITLE
Fix/1st rewards snap

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1318,7 +1318,7 @@ class DEX(IconScoreBase):
         day_remaining_us = U_SECONDS_DAY - day_elapsed_us
 
         if length == 0:
-            average = (current_value * day_elapsed_us) // U_SECONDS_DAY
+            average = (current_value * day_remaining_us) // U_SECONDS_DAY
 
             self._baln_snapshot[_id]['ids'][length] = current_id
             self._baln_snapshot[_id]['values'][length] = current_value
@@ -1369,7 +1369,7 @@ class DEX(IconScoreBase):
         day_remaining_us = U_SECONDS_DAY - day_elapsed_us
 
         if length == 0:
-            average = (current_value * day_elapsed_us) // U_SECONDS_DAY
+            average = (current_value * day_remaining_us) // U_SECONDS_DAY
 
             self._total_supply_snapshot[_id]['ids'][length] = current_id
             self._total_supply_snapshot[_id]['values'][length] = current_value

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1227,6 +1227,16 @@ class DEX(IconScoreBase):
                 self._dividends.get(), Dividends)
             self._dividends_done.set(dividends.distribute())
 
+    @external(readonly=True)
+    def inspectBalanceSnapshot(self, _account: Address, _id: int, _snapshot_id: int) -> dict:
+        return {
+            'ids': self._account_balance_snapshot[_id][_account]['ids'][_snapshot_id],
+            'values': self._account_balance_snapshot[_id][_account]['values'][_snapshot_id],
+            'avgs': self._account_balance_snapshot[_id][_account]['avgs'][_snapshot_id],
+            'time': self._account_balance_snapshot[_id][_account]['time'][_snapshot_id],
+            'length': self._account_balance_snapshot[_id][_account]['length'][0]
+        }
+
     def _update_account_snapshot(self, _account: Address, _id: int) -> None:
         """
         Updates a user's balance 24h avg snapshot


### PR DESCRIPTION
Total supply was snapshotted with the complement of remaining time. This performs the proper calculation for 1st day snapshots.