### PR TITLE
Hotfix/rewards distribution

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1318,7 +1318,7 @@ class DEX(IconScoreBase):
         day_remaining_us = U_SECONDS_DAY - day_elapsed_us
 
         if length == 0:
-            average = (current_value * day_elapsed_us) // U_SECONDS_DAY
+            average = (current_value * day_remaining_us) // U_SECONDS_DAY
 
             self._baln_snapshot[_id]['ids'][length] = current_id
             self._baln_snapshot[_id]['values'][length] = current_value
@@ -1369,7 +1369,7 @@ class DEX(IconScoreBase):
         day_remaining_us = U_SECONDS_DAY - day_elapsed_us
 
         if length == 0:
-            average = (current_value * day_elapsed_us) // U_SECONDS_DAY
+            average = (current_value * day_remaining_us) // U_SECONDS_DAY
 
             self._total_supply_snapshot[_id]['ids'][length] = current_id
             self._total_supply_snapshot[_id]['values'][length] = current_value

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1490,7 +1490,8 @@ class DEX(IconScoreBase):
 
     @external(readonly=True)
     def getTotalValue(self, _name: str, _snapshot_id: int) -> int:
-        return self.totalSupplyAt(self._named_markets[_name], _snapshot_id)
+        # return self.totalSupplyAt(self._named_markets[_name], _snapshot_id)
+        return self.totalSupply(self._named_markets[_name])
 
     @external(readonly=True)
     def getBalnSnapshot(self, _name: str, _snapshot_id: int) -> int:
@@ -1506,7 +1507,8 @@ class DEX(IconScoreBase):
             revert(f"{TAG}: Offset must be equal to or greater than Zero.")
         rv = {}
         for addr in self._active_addresses[_id].range(_offset, _offset + _limit):
-            snapshot_balance = self.balanceOfAt(addr, _id, _snapshot_id)
+            # snapshot_balance = self.balanceOfAt(addr, _id, _snapshot_id)
+            snapshot_balance = self.balanceOf(addr, _id)
             if snapshot_balance:
                 rv[str(addr)] = snapshot_balance
         return rv

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1227,6 +1227,16 @@ class DEX(IconScoreBase):
                 self._dividends.get(), Dividends)
             self._dividends_done.set(dividends.distribute())
 
+    @external(readonly=True)
+    def inspectBalanceSnapshot(self, _account: Address, _id: int, _snapshot_id: int) -> dict:
+        return {
+            'ids': self._account_balance_snapshot[_id][_account]['ids'][_snapshot_id],
+            'values': self._account_balance_snapshot[_id][_account]['values'][_snapshot_id],
+            'avgs': self._account_balance_snapshot[_id][_account]['avgs'][_snapshot_id],
+            'time': self._account_balance_snapshot[_id][_account]['time'][_snapshot_id],
+            'length': self._account_balance_snapshot[_id][_account]['length'][0]
+        }
+
     def _update_account_snapshot(self, _account: Address, _id: int) -> None:
         """
         Updates a user's balance 24h avg snapshot

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -754,7 +754,7 @@ class DEX(IconScoreBase):
         :return: the _owner's balance of the token type requested
         """
         if _id == self._SICXICX_POOL_ID:
-            order_id = self._icx_queue_order_id[self.msg.sender]
+            order_id = self._icx_queue_order_id[_owner]
             if not order_id:
                 return 0
             return self._icx_queue._get_node(order_id).get_value1()


### PR DESCRIPTION
Fix method zeroing out rewards in the ICX queue after the first day.

Add temporary method to read in current balances in lieu of snapshotted balances, until they can be fixed. This hotfix method should only be used until all reward snapshots are migrated to the correct value, then it will be reverted.