### PR TITLE
Dex snapshot migration

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -19,7 +19,7 @@
     "# Note that running on the private tbears server will require the number of top P-Reps \n",
     "# be set to 4 in the staking contract or it will fail to deploy.\n",
     "\n",
-    "network = \"yeouido\"  # set this to one of mainnet, yeouido, euljiro, pagoda, or custom\n",
+    "network = \"custom\"  # set this to one of mainnet, yeouido, euljiro, pagoda, or custom\n",
     "\n",
     "connections = {\n",
     "\"mainnet\": {\"iconservice\": \"https://ctz.solidwallet.io\",       \"nid\": 1},\n",
@@ -645,7 +645,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Cell 7a\n",
@@ -720,7 +722,7 @@
     "# Cell 8\n",
     "# Deploy or Update a single SCORE\n",
     "\n",
-    "contract_name = 'rewards'\n",
+    "contract_name = 'dex'\n",
     "update = 1\n",
     "params = {}\n",
     "if update == 0 and contract_name != 'governance':\n",
@@ -1481,14 +1483,14 @@
     "# Cell 26\n",
     "\n",
     "transaction = TransactionBuilder()\\\n",
-    "    .from_(wallets[99].get_address())\\\n",
+    "    .from_(wallet.get_address())\\\n",
     "    .to(contracts['dex']['SCORE'])\\\n",
-    "    .value(1000 * ICX)\\\n",
+    "    .value(100 * ICX)\\\n",
     "    .step_limit(10000000)\\\n",
     "    .nid(NID)\\\n",
     "    .nonce(101)\\\n",
     "    .build()\n",
-    "signed_transaction = SignedTransaction(transaction, wallets[99])\n",
+    "signed_transaction = SignedTransaction(transaction, wallet)\n",
     "tx_hash = icon_service.send_transaction(signed_transaction)\n",
     "tx_hash\n",
     "\n",
@@ -2389,6 +2391,286 @@
     "        print(f'{item} \\n')\n",
     "if res['status'] == 0:\n",
     "    print(f'Failure: {res[\"failure\"]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Snapshots and Repairs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Repair a single address and test.\n",
+    "# Do not use on a live network\n",
+    "\n",
+    "def repair_and_test(_id, _address):    \n",
+    "    transaction = CallTransactionBuilder()\\\n",
+    "        .from_(btest_wallet.get_address())\\\n",
+    "        .to(contracts['governance']['SCORE'])\\\n",
+    "        .value(0)\\\n",
+    "        .step_limit(10000000)\\\n",
+    "        .nid(NID)\\\n",
+    "        .nonce(100)\\\n",
+    "        .method(\"repairSnapshots\")\\\n",
+    "        .params({\"_poolId\": _id, \"_addressList\":[_address]}) \\\n",
+    "        .build()\n",
+    "    signed_transaction = SignedTransaction(transaction, btest_wallet)\n",
+    "    tx_hash = icon_service.send_transaction(signed_transaction)\n",
+    "\n",
+    "    res = get_tx_result(tx_hash)\n",
+    "    print(f'Status: {res[\"status\"]}')\n",
+    "    if len(res[\"eventLogs\"]) > 0:\n",
+    "        for item in res[\"eventLogs\"]:\n",
+    "            print(f'{item} \\n')\n",
+    "    if res['status'] == 0:\n",
+    "        print(f'Failure: {res[\"failure\"]}')\n",
+    "        \n",
+    "    result = call_tx('dex', 'inspectBalanceSnapshot', {'_id': _id, '_snapshot_id': 0, '_account': _address})\n",
+    "\n",
+    "    updated_snapshot_idx = int(result['length'], 0)\n",
+    "    \n",
+    "    print(\"Getting updated snapshot...\")\n",
+    "    result = call_tx('dex', 'inspectBalanceSnapshot', {'_id': _id, '_snapshot_id': updated_snapshot_idx - 1, '_account': _address})\n",
+    "\n",
+    "confirm = input(f'About to modify contracts on {network} - requires write lock. Proceed (Yes/No)? ')\n",
+    "if confirm == 'Yes':\n",
+    "    repair_and_test(1, wallet.get_address())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Turn off DEX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "if network == \"custom\":\n",
+    "    confirm = \"Yes\"\n",
+    "else:\n",
+    "    confirm = input(f'About to pause DEX on {network}. Proceed (Yes/No)? ')\n",
+    "if confirm == 'Yes':\n",
+    "    send_tx('governance', 0, 'turnDexOff', {}, btest_wallet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Migrate Addresses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def migrate_snapshots(migrations, batch_size = 40):\n",
+    "    \n",
+    "    dex_on_status = call_tx('dex', 'getDexOn', {})\n",
+    "    \n",
+    "    if int(dex_on_status, 0) > 0:\n",
+    "        print(\"Error: cannot migrate snapshots while DEX is on...\")\n",
+    "        return\n",
+    "    \n",
+    "    for migration in migrations:\n",
+    "        pool_id = migration[\"id\"]\n",
+    "        address_migration_list = migration[\"addresses\"]\n",
+    "        address_batches = [\n",
+    "            address_migration_list[i:i+batch_size] for i in range(0, len(address_migration_list), batch_size)\n",
+    "        ]\n",
+    "        \n",
+    "        for batch in address_batches:\n",
+    "            send_tx('governance', 0, 'repairSnapshots', {\"_poolId\": pool_id, \"_addressList\":batch}, btest_wallet)\n",
+    "            sleep(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "migrations = [\n",
+    "    {\n",
+    "        \"id\": 1,\n",
+    "        \"addresses\": [\n",
+    "            wallets[1].get_address(),\n",
+    "            wallets[2].get_address(),\n",
+    "            wallets[3].get_address(),\n",
+    "            wallets[4].get_address()\n",
+    "        ]\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": 2,\n",
+    "        \"addresses\": [\n",
+    "            wallets[1].get_address(),\n",
+    "            wallets[2].get_address(),\n",
+    "            wallets[5].get_address(),\n",
+    "            wallets[6].get_address(),\n",
+    "            wallets[10].get_address(),\n",
+    "            wallets[11].get_address(),\n",
+    "            wallets[12].get_address(),\n",
+    "            wallets[15].get_address(),\n",
+    "        ]\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "migrate_snapshots(migrations, 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Turn on DEX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if network == \"custom\":\n",
+    "    confirm = \"Yes\"\n",
+    "else:\n",
+    "    confirm = input(f'About to pause DEX on {network}. Proceed (Yes/No)? ')\n",
+    "if confirm == 'Yes':\n",
+    "    send_tx('governance', 0, 'turnDexOn', {}, btest_wallet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Enable/Disable Time Weighted Averages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if network == \"custom\":\n",
+    "    confirm = \"Yes\"\n",
+    "else:\n",
+    "    confirm = input(f'About to change time weighting settings DEX on {network}. Proceed (Yes/No)? ')\n",
+    "if confirm == 'Yes':\n",
+    "    send_tx('governance', 0, 'setTimeWeighting', {\"_value\": True}, btest_wallet)\n",
+    "    call_tx('dex', 'getTimeWeighting', {})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Batch Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Supply Sum Check\n",
+    "\n",
+    "\"\"\"\n",
+    "This cell defines funtions that can be used in comparing results of getDataBatch with expected outputs.\n",
+    "\"\"\"\n",
+    "\n",
+    "def supply_sum_check(limit, snapshot_id, name):\n",
+    "    total_value = 0\n",
+    "    offset = 0\n",
+    "    while(True):\n",
+    "        call = CallBuilder().from_(wallet.get_address())\\\n",
+    "                            .to(contracts['dex']['SCORE'])\\\n",
+    "                            .method('getDataBatch')\\\n",
+    "                            .params({'_name': name, '_limit': limit, '_offset': offset, '_snapshot_id': snapshot_id}) \\\n",
+    "                            .build()\n",
+    "        result = icon_service.call(call)\n",
+    "        if len(result.items())== 0:\n",
+    "            break\n",
+    "        for k,v in result.items():\n",
+    "            total_value += int(v, 0)\n",
+    "        offset += limit\n",
+    "    print(f\"Summed Addresses: {total_value}\")\n",
+    "    total_call = CallBuilder().from_(wallet.get_address())\\\n",
+    "                            .to(contracts['dex']['SCORE'])\\\n",
+    "                            .method('getTotalValue')\\\n",
+    "                            .params({'_name': name, '_snapshot_id': snapshot_id}) \\\n",
+    "                            .build()\n",
+    "    total_result = icon_service.call(total_call)\n",
+    "    print(f\"Pool Total: {int(total_result,0)}\")\n",
+    "\n",
+    "def supply_sum_check_optional(limit, snapshot_id, name, time_weighting):\n",
+    "    total_value = 0\n",
+    "    offset = 0\n",
+    "    while(True):\n",
+    "        call = CallBuilder().from_(wallet.get_address())\\\n",
+    "                            .to(contracts['dex']['SCORE'])\\\n",
+    "                            .method('getDataBatchOptional')\\\n",
+    "                            .params({'_name': name, '_limit': limit, '_offset': offset, '_snapshot_id': snapshot_id, '_twa': time_weighting}) \\\n",
+    "                            .build()\n",
+    "        result = icon_service.call(call)\n",
+    "        if len(result.items())== 0:\n",
+    "            break\n",
+    "        for k,v in result.items():\n",
+    "            total_value += int(v, 0)\n",
+    "        offset += limit\n",
+    "    print(f\"Summed Addresses: {total_value}\")\n",
+    "    total_call = CallBuilder().from_(wallet.get_address())\\\n",
+    "                            .to(contracts['dex']['SCORE'])\\\n",
+    "                            .method('getTotalValueOptional')\\\n",
+    "                            .params({'_name': name, '_snapshot_id': snapshot_id, '_twa': time_weighting}) \\\n",
+    "                            .build()\n",
+    "    total_result = icon_service.call(total_call)\n",
+    "    print(f\"Pool Total: {int(total_result,0)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "supply_sum_check(50, 1, \"sICX/bnUSD\")\n",
+    "supply_sum_check(50, 1, \"sICX/ICX\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Calling without time weighting...\")\n",
+    "supply_sum_check_optional(50, 1, \"sICX/bnUSD\", False)\n",
+    "supply_sum_check_optional(50, 1, \"sICX/ICX\", False)\n",
+    "\n",
+    "print(\"\\n -------- \\n\")\n",
+    "\n",
+    "print(\"Calling with time weighting...\")\n",
+    "supply_sum_check_optional(50, 1, \"sICX/bnUSD\", True)\n",
+    "supply_sum_check_optional(50, 1, \"sICX/ICX\", True)\n"
    ]
   },
   {

--- a/core_contracts/governance/governance.py
+++ b/core_contracts/governance/governance.py
@@ -401,6 +401,24 @@ class Governance(IconScoreBase):
         dex.setTimeWeighting(_value)
 
     @external
+    @only_owner
+    def turnDexOff(self):
+        dex = self.create_interface_score(self.addresses['dex'], DexInterface)
+        dex.turnDexOff()
+
+    @external
+    @only_owner
+    def turnDexOn(self):
+        dex = self.create_interface_score(self.addresses['dex'], DexInterface)
+        dex.turnDexOn()
+
+    @external
+    @only_owner
+    def repairSnapshots(self, _poolId: int, _addressList: List[Address]):
+        dex = self.create_interface_score(self.addresses['dex'], DexInterface)
+        dex.repairSnapshots(_poolId, _addressList)
+
+    @external
     def tokenFallback(self, _from: Address, _value: int, _data: bytes) -> None:
         """
         Used only to receive sICX for unstaking.

--- a/core_contracts/governance/governance.py
+++ b/core_contracts/governance/governance.py
@@ -393,6 +393,12 @@ class Governance(IconScoreBase):
     def addUsersToActiveAddresses(self, _poolId: int, _addressList: List[Address]):
         dex = self.create_interface_score(self.addresses['dex'], DexInterface)
         dex.addLpAddresses(_poolId, _addressList)
+    
+    @external
+    @only_owner
+    def setTimeWeighting(self, _value: bool):
+        dex = self.create_interface_score(self.addresses['dex'], DexInterface)
+        dex.setTimeWeighting(_value)
 
     @external
     def tokenFallback(self, _from: Address, _value: int, _data: bytes) -> None:

--- a/core_contracts/governance/interfaces.py
+++ b/core_contracts/governance/interfaces.py
@@ -99,6 +99,10 @@ class DexInterface(InterfaceScore):
         pass
 
     @interface
+    def turnDexOff(self) -> None:
+        pass
+
+    @interface
     def permit(self, _id: int, _permission: bool):
         pass
 
@@ -146,6 +150,13 @@ class DexInterface(InterfaceScore):
     def addLpAddresses(self, _poolId: int, _addresses: List[Address]) -> None:
         pass
 
+    @interface
+    def setTimeWeighting(self, _value: bool) -> None:
+        pass
+
+    @interface
+    def repairSnapshots(self, _poolId: int, _addresses: List[Address]) -> None:
+        pass
 
 # An interface to the Rewards SCORE
 class RewardsInterface(InterfaceScore):


### PR DESCRIPTION
This PR adds the final fix to snapshots, and a migration path to get the data working again. Note that the migration is not necessary, as it will happen automatically at the turn of the day. This just gives a way for LPs to stop getting rewards diluted by last minute suppliers.

Since this is a larger PR, it may be easier to see the changes by clicking on the individual commits, they are fairly well-contained.

This does the following:

`[DEX] Optional Time Weighting in getDataBatch` - This adds 2 new methods that give optional time-weighted versions of the getDataBatch query and the get total value query. These have a _twa flag that can be used to test the time-weighted version vs the non time-weighted version of the call. Additionally, this introduces a flag into the DEX set by governance. Once the second version of the call is migrated, it can be set turning the `getDataBatch` to the time-weighted version.

`Snapshot Repair Methods` - These methods can be called on slices of the snapshot DB, to restore it to a clean state as if the users had been supplying liquidity from the start of the day.

`[DEX] Fix to online average algorithm in snapshots` - This fixes the online average algorithm used in snapshots on the DEX. Previously, balances were credited too far into the window. Check commit description/details for a more complete description of the change.

`Governance methods for DEX migration` - These can be called on the DEX as the governance contract prepares to migrate it. The flow will be:
1. contract upgrade
2. Turn dex off
3. call migrate function as in depicted jupyter notebook below
4. turn on dex

`[jupyter] Add DEX migration methods ` these are example migration methods/workflow for the DEX