### PR TITLE
send retire fee to borrowers and add setter methods.

### DIFF
--- a/Balanced Clean Install.ipynb
+++ b/Balanced Clean Install.ipynb
@@ -701,7 +701,7 @@
     "# Cell 8\n",
     "# Deploy or Update a single SCORE\n",
     "\n",
-    "contract_name = 'baln'\n",
+    "contract_name = 'governance'\n",
     "update = 1\n",
     "params = {}\n",
     "if update == 0 and contract_name != 'governance':\n",
@@ -944,6 +944,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Set redemption fee"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "send_tx('governance', 0, 'setRedeemBatchSize', {'_value': 10}, btest_wallet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Tests with multiple wallets and redemptions"
    ]
   },
@@ -1043,7 +1059,7 @@
    "source": [
     "# Mint some bnUSD to first 70 wallets.\n",
     "\n",
-    "for i in range(80, 100):\n",
+    "for i in range(60, 100):\n",
     "    res = send_tx('loans', 500 * ICX, 'depositAndBorrow', {'_asset': 'bnUSD', '_amount': 100 * ICX}, wallets[i])"
    ]
   },

--- a/core_contracts/governance/governance.py
+++ b/core_contracts/governance/governance.py
@@ -415,6 +415,18 @@ class Governance(IconScoreBase):
         loans.setRedemptionFee(_fee)
 
     @external
+    @only_owner
+    def setMaxRetirePercent(self, _value: int) -> None:
+        loans = self.create_interface_score(self.addresses['loans'], LoansInterface)
+        loans.setMaxRetirePercent(_value)
+
+    @external
+    @only_owner
+    def setRedeemBatchSize(self, _value: int) -> None:
+        loans = self.create_interface_score(self.addresses['loans'], LoansInterface)
+        loans.setRedeemBatchSize(_value)
+
+    @external
     def tokenFallback(self, _from: Address, _value: int, _data: bytes) -> None:
         """
         Used only to receive sICX for unstaking.

--- a/core_contracts/governance/interfaces.py
+++ b/core_contracts/governance/interfaces.py
@@ -79,11 +79,19 @@ class LoansInterface(InterfaceScore):
         pass
 
     @interface
-    def delegate(self, _user_delegations: List[PrepDelegations]):
+    def delegate(self, _user_delegations: List[PrepDelegations]) -> None:
         pass
 
     @interface
     def setRedemptionFee(self, _fee: int) -> None:
+        pass
+
+    @interface
+    def setMaxRetirePercent(self, _value: int) -> None:
+        pass
+
+    @interface
+    def setRedeemBatchSize(self, _value: int) -> None:
         pass
 
 

--- a/core_contracts/loans/loans/loans.py
+++ b/core_contracts/loans/loans/loans.py
@@ -984,6 +984,8 @@ class Loans(IconScoreBase):
     @external
     @only_admin
     def setMaxRetirePercent(self, _value: int) -> None:
+        if not 0 <= _value <= 10000:
+            revert(f'Input parameter must be in the range 0 to 10000 points.')
         self._max_retire_percent.set(_value)
 
     @external


### PR DESCRIPTION
Changed retire method so the borrower gets more debt forgiven for the amount of sICX sold by the amount of the fee. So with the current fee of 5% the borrower will be selling their sICX at a 5% premium over the oracle price.

Also added setter methods.
