### PR TITLE
Sicx eventlog

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1106,10 +1106,19 @@ class DEX(IconScoreBase):
         self._icx_queue_total.set(self._icx_queue_total.get() - order_icx_value)
         self._update_total_supply_snapshot(self._SICXICX_POOL_ID)
 
+        # Compute effective fill price after fees for eventlog
+        effective_fill_price = (EXA * order_icx_value) // _value
+
+        # Publish an eventlog with the swap results
+        self.Swap(self._SICXICX_POOL_ID, self._sicx.get(), self._sicx.get(), None, _sender,
+                  _sender, _value, order_icx_value, self.now(), conversion_fees,
+                  baln_fees, self._icx_queue_total.get(), 
+                  0, self._get_sicx_rate(), effective_fill_price)
+
         # Settle fees to dividends and ICX converted to the sender
         sicx_score.transfer(self._dividends.get(), baln_fees)
         self.icx.transfer(_sender, order_icx_value)
-    
+
     def _get_unit_value(self, _token_address: Address):
         if _token_address is None:
             return 10 ** 18

--- a/core_contracts/dividends/dividends.py
+++ b/core_contracts/dividends/dividends.py
@@ -199,6 +199,13 @@ class Dividends(IconScoreBase):
         super().on_install()
         self._governance.set(_governance)
 
+        self._accepted_tokens.put(ZERO_SCORE_ADDRESS)
+        self._snapshot_id.set(1)
+        self._max_loop_count.set(MAX_LOOP)
+        self._minimum_eligible_debt.set(MINIMUM_ELIGIBLE_DEBT)
+        self._add_initial_categories()
+        self._distribution_activate.set(False)
+
     def on_update(self) -> None:
         super().on_update()
 

--- a/core_contracts/dividends/dividends.py
+++ b/core_contracts/dividends/dividends.py
@@ -199,15 +199,6 @@ class Dividends(IconScoreBase):
         super().on_install()
         self._governance.set(_governance)
 
-        self._accepted_tokens.put(ZERO_SCORE_ADDRESS)
-        loans = self.create_interface_score(Address.from_string('cx66d4d90f5f113eba575bf793570135f9b10cece1'), LoansInterface)
-        day = loans.getDay()
-        self._snapshot_id.set(day)
-        self._max_loop_count.set(MAX_LOOP)
-        self._minimum_eligible_debt.set(MINIMUM_ELIGIBLE_DEBT)
-        self._add_initial_categories()
-        self._distribution_activate.set(False)
-
     def on_update(self) -> None:
         super().on_update()
 


### PR DESCRIPTION
Fixes #150.

Add support for `sICX/ICX` pool eventlogs, which behave differently from the other eventlogs. Note to @pranav925 - pool id should work with eventlogs when this is deployed, but one side will be 0 for quote. You may need to handle this as a special case.

Additionally, this fixes the dividends score for the batch deploy method.