### PR TITLE
Updated logic for non Balanced pools

### DIFF
--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -1726,7 +1726,10 @@ class DEX(IconScoreBase):
         user_quote_holdings = self._balance[_id][self.msg.sender] \
                               * self._pool_total[_id][_quoteToken] // self.totalSupply(_id)
 
-        self._revert_below_minimum(user_quote_holdings, _quoteToken)
+        # Only add restrictions to Balanced pools
+        if _id < 5:
+            self._revert_below_minimum(user_quote_holdings, _quoteToken)
+        
         self._active_addresses[_id].add(self.msg.sender)
 
         self._update_account_snapshot(_owner, _id)

--- a/core_contracts/dex/dex.py
+++ b/core_contracts/dex/dex.py
@@ -674,7 +674,7 @@ class DEX(IconScoreBase):
 
         self._active_addresses[_id].add(_to)
         if self._balance[_id][_from] == 0:
-            self._active_addresses[_id].discard(_from)
+            self._active_addresses[_id].remove(_from)
 
         self.TransferSingle(self.msg.sender, _from, _to, _id, _value)
 


### PR DESCRIPTION
This does the following:

- Fix the transfer method in the case that a user transfers their full balance
- Remove minimum add size (specified in quote coin) for non balanced pools. These start with pool id >= 5